### PR TITLE
Remove not needed variable escape

### DIFF
--- a/bin/EditRecipe
+++ b/bin/EditRecipe
@@ -49,6 +49,6 @@ if Boolean "no-edit"
 then 
    echo $localrecipe
 else
-   [ "$EDITOR" ] || Die 'Please set your \$EDITOR variable using `export EDITOR='...'`.'
+   [ "$EDITOR" ] || Die 'Please set your $EDITOR variable using `export EDITOR='...'`.'
    $EDITOR "$localrecipe/Recipe"
 fi


### PR DESCRIPTION
Small fix. String does not need the escape.