### PR TITLE
Adds build_in_programs=yes to Compile

### DIFF
--- a/Functions/BuildType_configure
+++ b/Functions/BuildType_configure
@@ -27,6 +27,7 @@ configure_do_configuration() {
          --verbose
          --configure $configure
          `[ "$override_default_options" = "yes" ] && echo "--no-default-options"`
+         `[ "$build_in_programs" = "yes" ] && echo "--programs"`
       )
       PrepareProgram $batch $keep ${prepareoptions[*]} "$appname" "$versionnumber" ${config:+"--" "${config[@]}"} || return 1
    ) || return 1

--- a/bin/PrepareProgram
+++ b/bin/PrepareProgram
@@ -31,6 +31,7 @@ Add_Option_Entry   "c" "configure" "Specify program to be used as 'configure' sc
 Add_Option_Boolean "a" "autoconf" "Assume configure is based on autoconf, skipping detection."
 Add_Option_Boolean "A" "no-autoconf" "Assume configure is NOT based on autoconf, skipping detection."
 Add_Option_Boolean "D" "no-default-options" "Skip detection altogether, use only configure options passed on the command-line."
+Add_Option_Boolean "p" "programs" "Prepare for build directly in /Programs, not $goboIndex"
 
 Parse_Options "$@"
 
@@ -110,7 +111,7 @@ rm -f config.cache
 
 Exists "$configureprogram" || Die "configure script "`[ $configureprogram != "./configure" ] && echo " ($configureprogram) "`"not found."
    
-if [ "$goboIndex" ]
+if [ "$goboIndex" ] && ! Boolean "programs"
 then
    configureprefix="$goboIndex"
    configuresettings="$goboSettings"
@@ -118,7 +119,7 @@ then
 else
    configureprefix="$programdir"
    configuresettings="$settingsdir"
-   configuremandir="${target}/Shared/man"
+   configuremandir="${target}/share/man"
 fi
 configurevariable="$goboVariable"
 


### PR DESCRIPTION
Adding this for consideration. Essentially it reverts to the old-school "build in /Programs then symlink" behavior instead of the current "build on /usr and store in /Programs". I used this for building OpenResty, which assumes an `/opt`-like prefix and is pretty annoying about where it builds and finds things. I'm not sure about the implications this may have for Runner (perhaps recipes using this may need Runner to be disabled?) so I'm opening it for discussion first. Still, it's an opt-in feature so having it around shouldn't hurt.