### PR TITLE
Fix typo while using compileRecipesDir

### DIFF
--- a/bin/UpdateRecipes
+++ b/bin/UpdateRecipes
@@ -41,7 +41,7 @@ fi
 # Prepare Environment
 ##################################################
 
-Check_Dir_Variable compileRecipeDir
+Check_Dir_Variable compileRecipesDir
 
-cd $compileRecipeDir
+cd $compileRecipesDir
 git pull


### PR DESCRIPTION
There was a little typo while using the `$compileRecipesDir` variable.