### PR TITLE
--pure: Add Bison and Flex to Dependencies

### DIFF
--- a/Resources/Dependencies
+++ b/Resources/Dependencies
@@ -3,9 +3,11 @@ Autogen         # potentially used by BuildType_configure
 Automake        # potentially used by BuildType_configure 
 Bash
 BinUtils
+Bison
 CMake           # used by BuildType_cmake
 CoreUtils
 FindUtils
+Flex
 GCC
 Gawk
 Glibc


### PR DESCRIPTION
Many Recipes depend on `Flex` implicitly, and at least GCC itself depends on `Bison`.