### PR TITLE
Updated ApplyVariables to make use of Bash-5.0 ideas

### DIFF
--- a/bin/ApplyVariables
+++ b/bin/ApplyVariables
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Imports ###################################################################
 
@@ -7,42 +7,32 @@ Import OptionParser
 
 ### Options ###################################################################
 
-helpOnNoArguments=yes
-scriptNotes="$scriptName processes a file replacing instances of variables marked
+helpOnNoArguments='yes'
+scriptNotes="${scriptName} processes a file replacing instances of variables marked
 with special indicators ('@%', '%@' by default) with the contents of equivalent
 environment variables."
-Add_Option_Entry "o" "open" "Opening mark." "@%"
-Add_Option_Entry "c" "close" "Closing mark." "%@"
-Add_Option_Entry "i" "identifier" "Add a prefix identifier in the form of '<entry>_' to the opening markup."
+Add_Option_Entry 'o' 'open' 'Opening mark.' '@%'
+Add_Option_Entry 'c' 'close' 'Closing mark.' '%@'
+Add_Option_Entry 'i' 'identifier' 'Add a prefix identifier in the form of '\''<entry>_'\'' to the opening markup.'
 Parse_Options "$@"
 
 ### Operation #################################################################
 
-open=`Entry "open"`
-close=`Entry "close"`
-if Is_Entry "identifier"
+open=$(Entry 'open')       # opening brace (default '@%')
+close=$(Entry 'close')     # closing brace (default '%@')
+if Is_Entry 'identifier'   # variable name prefix (default '')
 then
-   open="${open}`Entry identifier`_"
+   open="${open}$(Entry identifier)_"
+fi
+filename=$(Arg 1)          # source filename
+
+# read contents of the ${filename} file
+# find/expand enviornment variables in contents
+# output expanded results to stdout
+if ! ApplyVariablesCore "${open}" "${close}" "${filename}"
+then
+   # if the function returns an error (commonly, if the file doesn't exist)
+   # throw an error and abort
+   Die "${filename}: failed"
 fi
 
-cat "$(Arg 1)" | python3 -c '
-import os,sys,string
-
-op=sys.argv[1]
-cl=sys.argv[2]
-for line in sys.stdin.readlines():
-   while 1:
-      op_index=line.find(op)
-      if op_index == -1:
-         break
-      cl_index=line.find(cl)
-      if cl_index == -1:
-         break
-      var = line[op_index + len(op):cl_index]
-      try:
-         val = os.environ[var]
-      except:
-         val = ""
-      line = line.replace(op + var + cl, val)
-   print(line, end=" ")
-' "$open" "$close"

--- a/bin/ApplyVariablesCore
+++ b/bin/ApplyVariablesCore
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import string
+
+# set console args (expect 3)
+op=sys.argv[1]
+cl=sys.argv[2]
+filename=sys.argv[3]
+
+# open 'filename' with error handling
+try:
+   with open(filename, "r") as f:
+      # find+replace all variables in filename
+      # where each variable is checked against the enviorment hashtable
+      # default value to blank string
+      for line in f.readlines():
+         while 1:
+            # find variable in line
+            op_index=line.find(op)
+            if op_index == -1:
+               break
+            cl_index=line.find(cl)
+            if cl_index == -1:
+               break
+            var = line[op_index + len(op):cl_index]
+
+            # get variable from environment (default "")
+            try:
+               val = os.environ[var]
+            except:
+               val = ""
+
+            # substitue the variable's value in the line
+            line = line.replace(op + var + cl, val)
+
+         # output substituted line to stdout
+         print(line, end=" ")
+
+except:  # file cannot be opened
+   # handle error logging in calling script
+   # exit failure
+   exit (1)
+
+# exit success
+exit (0)


### PR DESCRIPTION
For [Compile Issue #47](https://github.com/gobolinux/Compile/issues/47)

- added a couple comments to the code
- updated code to better follow the [Bash Style Guide](https://github.com/bahamas10/bash-style-guide)
- separated `Python3` logic into it's own file `/bin/ApplyVariablesCore`
- updated python code to handle reading the file internally, rather than piping the output from `cat`
- if an error occurs while processing the file, use `Die` to handle the error message `ApplyVariables: <FILENAME>: failed`
- ran the bash code through [SpellCheck](https://www.shellcheck.net/)

**notes:**
Tested against the `017-GIT` version (unmodified), successful output was identical, as were the tested (non-fatal) error states. However the output for many fatal errors is different, previously you would see `python` errors or `cat` errors, however now the majority of them should be handled by/show output from the `Die` function.

With the new `Die` based error messages, it may be helpful to eventually add a `--no-color` option in the future. I have no plans of implementing it at the moment, just wanted to take note of it.

in testing, non-fatal error also showed identical responses when fed malformed data. An example being:
``` text
1:'@%VAR1%@' 2:'@%VAR2%@' 3:'@%VAR3%@'  # good  outputs  1:'value1' 2:'value2' 3:'value3'
1:'@%VAR1' 2:'@%VAR2%@' 3:'@%VAR3%@'    # bad   outputs  1:'' 3:'value3'
1:'%@VAR1@%'                            # bad   hangs perpetually
```
I'm unsure what line of code is causing the 3rd example to hang, nor do I have plans of fixing it at the moment; I am simply making note of its existance.