### PR TITLE
Added 'LuaRocks' Dependency

### DIFF
--- a/Resources/Dependencies
+++ b/Resources/Dependencies
@@ -12,6 +12,7 @@ Glibc
 GoboHide
 Grep
 Lua             # used by Lua rocks
+LuaRocks
 Make            # used by BuildType_configure|cmake
 Patch
 Perl            # used by RecipeLint script


### PR DESCRIPTION
`Runner` doesn't include the `LuaRocks` alien tree if `LuaRocks` isn't listed as a dependency. This means that if a dependency like `LuaRocks:MODULE_NAME` needs to be accessible at build time, the build may fail.

This can be seen directly when trying to compile `Awesome 4.3`, which requires `LuaRocks:lgi`. As encountered in [Recipes issue#128](https://github.com/gobolinux/Recipes/issues/128).