### PR TITLE
Safely make use of multi-threading by default

### DIFF
--- a/Resources/Defaults/Settings/Compile/Compile.conf
+++ b/Resources/Defaults/Settings/Compile/Compile.conf
@@ -14,3 +14,7 @@ httpSourceforge=http://downloads.sourceforge.net
 
 compileRecipesRepository=https://github.com/gobolinux/Recipes.git
 compileUpstreamBranch=master
+
+# By default, we configure Make to utilize all CPU threads minus 4.
+# Configure to your liking, eg "-j12". Or add other options here.
+compileMakeOptions="-j$(nproc --ignore 4)"


### PR DESCRIPTION
Prior to this commit Compile would run Make single-threaded by default. This commit ensures that Compile runs Make with all CPU threads available minus 4 (if possible). 

Leaving 4 threads available seems to be a good compromise as a default setting. The setting is backwards compatible and will run single-threaded on systems with 5 or less processing units available.