### PR TITLE
Choose best version number using `GuessLatest`

### DIFF
--- a/Functions/RecipeTools
+++ b/Functions/RecipeTools
@@ -33,7 +33,7 @@ function Find_Recipe_Program_And_Version() {
    then
       [ `ls "$entry" | wc -l` -eq 1 ] || {
          # pick latest
-         version=$(ls --sort=version "$compileRecipesDir/$program" | tail -n 1)
+         version=$(GuessLatest $(ls "$compileRecipesDir/$program"))
          if [ "$version" ]
          then
             recipedir="$compileRecipesDir/$program/$version"


### PR DESCRIPTION
Let's use [`GuessLatest`](https://github.com/gobolinux/Scripts/blob/master/bin/GuessLatest) rather than `ls --sort=version` to choose the best version number (if none is provided). The advantage is that `ls --sort=version` prefers development versions like git, svn, cvs, and so on... But in most cases we want the latest stable version, not some obscure developement version. `GuessLatest` will also ensure we are more flexible in the future, should more sophisticated sorting be necessairy or desired.

In practice that means, if we used Compile to eg install `Dit`, which has the following version numbers: `0.4  0.6  0.7  0.8  0.9  git`, previously Compile would have chosen `git`. Now it chooses the latest stable 0.9. Also frankly, we have many `svn`, `cvs`, `hg` and even `git` recipes laying around that are more outdated and broken than the stable versions.

Of course development versions can still be installed by just explicitly stating eg `Compile Dit git`.