### PR TITLE
Compile.conf: Update httpSourceforge URL.

### DIFF
--- a/Resources/Defaults/Settings/Compile/Compile.conf
+++ b/Resources/Defaults/Settings/Compile/Compile.conf
@@ -10,7 +10,7 @@ compileRecipesDir="$compileDir/Recipes"
 # Main free software repositories
 ftpGnu=ftp://ftp.gnu.org/gnu
 ftpAlphaGnu=ftp://alpha.gnu.org/gnu
-httpSourceforge=http://downloads.sourceforge.net
+httpSourceforge=https://downloads.sourceforge.net
 
 compileRecipesRepository=https://github.com/gobolinux/Recipes.git
 compileUpstreamBranch=master


### PR DESCRIPTION
Among the problems Repology complains is the redirection of URLs.  The main source of this annoyance is the redirection from old HTTP links to new HTTPS -- among them, Sourceforge links.

Fixes https://github.com/gobolinux/Compile/issues/71